### PR TITLE
Remove cursor.close() from finally

### DIFF
--- a/azure-function/python/GetBusData/__init__.py
+++ b/azure-function/python/GetBusData/__init__.py
@@ -98,6 +98,6 @@ def executeQueryJSON(procedure, payload=None):
                 result = {}        
         
     finally:
-        cursor.close()
+        pass
 
     return result


### PR DESCRIPTION
The cursor.close() in the finally block was causing an error on run that the cursor was being used before initialized and could not call on close. Since the 'with' statement is used close is automatically called when that block is exited.

The other option would be to explicitly look for pyodbc [SQL State Exception Codes](https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes?view=sql-server-ver15) in the except block

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ x] Other... Please describe:
```